### PR TITLE
Shorter test name

### DIFF
--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -213,9 +213,10 @@ class AllureAdapter implements PHPUnit_Framework_TestListener
     {
         if ($test instanceof \PHPUnit_Framework_TestCase) {
             $suiteName = $this->suiteName;
-            $methodName = $test->getName();
-            $this->methodName = $methodName;
-            $event = new TestCaseStartedEvent($this->uuid, get_class($test) . "::" . $methodName);
+            $testName = $test->getName();
+            $methodName = $this->methodName = $test->getName(false);
+
+            $event = new TestCaseStartedEvent($this->uuid, $testName);
             if (class_exists($suiteName, false) && method_exists($suiteName, $methodName)) {
                 $annotationManager = new Annotation\AnnotationManager(
                     Annotation\AnnotationProvider::getMethodAnnotations($suiteName, $methodName)


### PR DESCRIPTION
Method name looks better in reports instead of full class name with namespace + method.