### PR TITLE
Added processing of PHPUnit warnings as failures

### DIFF
--- a/src/Yandex/Allure/PhpUnit/AllurePhpUnit.php
+++ b/src/Yandex/Allure/PhpUnit/AllurePhpUnit.php
@@ -106,7 +106,8 @@ class AllurePhpUnit implements TestListener
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {
-        // TODO: Implement addWarning() method.
+        $event = new TestCaseFailedEvent();
+        Allure::lifecycle()->fire($event->withException($e)->withMessage($e->getMessage()));
     }
 
     /**

--- a/test/Yandex/Allure/Adapter/AllureAdapterTest.php
+++ b/test/Yandex/Allure/Adapter/AllureAdapterTest.php
@@ -5,6 +5,7 @@ namespace Yandex\Allure\Adapter;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
 use Exception;
 use org\bovigo\vfs\vfsStream;
 use Yandex\Allure\Adapter\Event\TestCaseBrokenEvent;
@@ -62,6 +63,19 @@ class AllureAdapterTest extends TestCase
         $this->assertEquals($event, $events[0]);
     }
 
+    public function testAddWarning()
+    {
+        $warning = new Warning(EXCEPTION_MESSAGE);
+        $time = $this->getTime();
+        $this->getAllureAdapter()->addWarning($this, $warning, $time);
+        $events = $this->getMockedLifecycle()->getEvents();
+        $event = new TestCaseFailedEvent();
+        $event->withException($warning)->withMessage(EXCEPTION_MESSAGE);
+        $this->assertEquals(1, sizeof($events));
+        $this->assertInstanceOf('\Yandex\Allure\Adapter\Event\TestCaseFailedEvent', $events[0]);
+        $this->assertEquals($event, $events[0]);
+    }
+    
     public function testAddFailure()
     {
         $exception = new AssertionFailedError(EXCEPTION_MESSAGE);


### PR DESCRIPTION
Added processing of PHPUnit warnings as failures since PHPUnit returns exit code 1 on warnings

Look at https://github.com/allure-framework/allure-phpunit/issues/47