### PR TITLE
Allow @testWith PHPUnit annotation by default

### DIFF
--- a/src/Yandex/Allure/PhpUnit/AllurePhpUnit.php
+++ b/src/Yandex/Allure/PhpUnit/AllurePhpUnit.php
@@ -41,7 +41,7 @@ class AllurePhpUnit implements TestListener
         'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException',
         'expectedExceptionCode', 'expectedExceptionMessage', 'group', 'large', 'medium',
         'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess',
-        'small', 'test', 'testdox', 'ticket', 'uses',
+        'small', 'test', 'testWith', 'testdox', 'ticket', 'uses',
     ];
 
     /**


### PR DESCRIPTION
@testWith is a very useful replacement for small data providers.
It would be useful to have it ignored by default.