### PR TITLE
Add compatibility for data providers without named sets.

### DIFF
--- a/src/Internal/TestLifecycle.php
+++ b/src/Internal/TestLifecycle.php
@@ -166,7 +166,7 @@ final class TestLifecycle implements TestLifecycleInterface
     private function buildTestInfo(string $test, ?string $host = null, ?string $thread = null): TestInfo
     {
         $dataLabelMatchResult = preg_match(
-            '#^([^\s]+)\s+with\s+data\s+set\s+"(.*)"\s+\(.+\)$#',
+            '#^([^\s]+)\s+with\s+data\s+set\s+(\#\d+|".+")\s+\(.+\)$#',
             $test,
             $matches,
         );

--- a/test/report/Generate/RetriesTest.php
+++ b/test/report/Generate/RetriesTest.php
@@ -57,6 +57,32 @@ class RetriesTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider providerIndexedData
+     */
+    #[
+        DisplayName('Reruns of test with indexed data provider are reported correctly'),
+        Description("Parameter `retry` has different value on each run but is excluded and doesn't have effect"),
+    ]
+    public function testRerunsOfTestWithIndexedDataProvider(string $firstValue, string $secondValue): void
+    {
+        Allure::parameter('First argument', $firstValue);
+        Allure::parameter('Second argument', $secondValue);
+        Allure::parameter('Run index', (string) $this->getRunIndex(__METHOD__), true);
+        $this->expectNotToPerformAssertions();
+    }
+  
+    /**
+     * @return iterable<array{string, string}>
+     */
+    public function providerIndexedData(): iterable
+    {
+        return [
+            ['a', 'b'],
+            ['b', 'b'],
+        ];
+    }
+
     private function getRunIndex(string $method): int
     {
         self::$runCounters[$method] ??= 0;


### PR DESCRIPTION
When a data provider does not use named keys for the sets the method name will have a suffix in the form of "with data set #[Index] ([Arguments])".

The regexp didn't account for this, which in turn lead to a crash when testing for a class with a broken method name, leading to the test being excluded from Allure reports.