### PR TITLE
Allure PHPUnit extension is not recognising the parameter path if the phpunit.xml.dist is placed in a different directory than root. #106

### DIFF
--- a/src/AllureExtension.php
+++ b/src/AllureExtension.php
@@ -92,9 +92,16 @@ final class AllureExtension implements Extension
 
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
-        $configSource = $parameters->has('config')
-            ? $parameters->get('config')
-            : null;
+        if ($configuration->hasConfigurationFile()) {
+            $path = dirname($configuration->configurationFile());
+            $configSource = $parameters->has('config')
+                ? $path . DIRECTORY_SEPARATOR . $parameters->get('config')
+                : null;
+        } else {
+            $configSource = $parameters->has('config')
+                ? $parameters->get('config')
+                : null;
+        }
 
         $testLifecycle = $this->testLifecycle ?? $this->createTestLifecycle($configSource);
 


### PR DESCRIPTION
If phpunit.xml.dist file is placed in a different path other than root. Then in CLI, if I am running below command from project root:

./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist

It is giving below error:

There was 1 PHPUnit test runner warning:

1) Bootstrapping of extension Qameta\Allure\PHPUnit\AllureExtension failed: Config file allure/allure.config.php doesn't exist
#0 /opt/homebrew/var/www/project/vendor/allure-framework/allure-phpunit/src/AllureExtension.php(39): Qameta\Allure\PHPUnit\AllureExtension->loadConfigData('allure/allure.c...')
#1 /opt/homebrew/var/www/project/vendor/allure-framework/allure-phpunit/src/AllureExtension.php(99): Qameta\Allure\PHPUnit\AllureExtension->createTestLifecycle('allure/allure.c...')
#2 /opt/homebrew/var/www/project/vendor/phpunit/phpunit/src/Runner/Extension/ExtensionBootstrapper.php(73): Qameta\Allure\PHPUnit\AllureExtension->bootstrap(Object(PHPUnit\TextUI\Configuration\Configuration), Object(PHPUnit\Runner\Extension\Facade), Object(PHPUnit\Runner\Extension\ParameterCollection))
#3 /opt/homebrew/var/www/project/vendor/phpunit/phpunit/src/TextUI/Application.php(418): PHPUnit\Runner\Extension\ExtensionBootstrapper->bootstrap('Qameta\\Allure\\P...', Array)
#4 /opt/homebrew/var/www/project/vendor/phpunit/phpunit/src/TextUI/Application.php(131): PHPUnit\TextUI\Application->bootstrapExtensions(Object(PHPUnit\TextUI\Configuration\Configuration))
#5 /opt/homebrew/var/www/project/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run(Array)
#6 /opt/homebrew/var/www/project/vendor/bin/phpunit(122): include('/opt/homebrew/v...')
#7 {main}


Steps to reproduce the behavior:

1. Clone this repository https://github.com/manishranjan-adobe/php-testing-allure
2. Run composer install
3. From the project's root directory, run the below command.
     vendor/bin/phpunit -c allure/phpunit.xml tests/UserTest.php


Expected behavior
It was supposed to work smoothly with all configurations being used properly and allure reports being generated.

Actual behavior
Getting error as described in description and no allure reports are getting generated. AllureExtension is not taking absolute path as it should be. This behaviour was working correctly with PHPUnit 9 config file.