### PR TITLE
Upgrade to php 84

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
@@ -41,6 +38,9 @@ jobs:
           extensions: pcntl, posix
           coverage: xdebug
           ini-values: error_reporting=E_ALL
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
 
       - name: Install dependencies
         run: composer update

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This adapter only generates JSON files containing information about tests. See [
 ## Installation && Usage
 **Note:** this adapter supports Allure 2.x.x only.
 
-Supported PHP versions: 8.1-8.3.
+Supported PHP versions: 8.1-8.4.
 
 In order to use this adapter you need to add a new dependency to your **composer.json** file:
 ```

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "phpunit/phpunit": "^10"
   },
   "require-dev": {
-    "brianium/paratest": "^7",
+    "phpunit/phpunit": "~10.4.0",
+    "brianium/paratest": "^7.3",
     "psalm/plugin-phpunit": "^0.18.4",
     "squizlabs/php_codesniffer": "^3.7.2",
     "vimeo/psalm": "^5.15"

--- a/composer.json
+++ b/composer.json
@@ -29,19 +29,27 @@
     "source": "https://github.com/allure-framework/allure-phpunit"
   },
   "require": {
-    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "allure-framework/allure-php-commons": "^2",
-    "phpunit/phpunit": "^10"
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+    "allure-framework/allure-php-commons": "^2.0",
+    "phpunit/phpunit": "^10 || ^11 || ^12"
   },
   "require-dev": {
-    "phpunit/phpunit": "~10.4.0",
+    "phpunit/phpunit": "~10.4.0 || ^11 || ^12",
     "brianium/paratest": "^7.3",
-    "psalm/plugin-phpunit": "^0.18.4",
+    "psalm/plugin-phpunit": "^0.19.3",
     "squizlabs/php_codesniffer": "^3.7.2",
-    "vimeo/psalm": "^5.15"
+    "vimeo/psalm": "^6.9"
   },
   "conflict": {
     "amphp/byte-stream": "<1.5.1",
+    "amphp/dns": "<2.2.0",
+    "amphp/socket": "<2.3.1",
+    "amphp/cache": "<2.0.1",
+    "amphp/process": "<2.0.3",
+    "amphp/parser": "<1.1.1",
+    "daverandom/libdns": "<2.1.0",
+    "spatie/array-to-xml": "<3.3.0",
+    "ramsey/uuid": "<4.3.0",
     "brianium/paratest": "<7.0.3"
   },
   "autoload": {

--- a/phpunit.10.0.xml
+++ b/phpunit.10.0.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-        colors="true"
-        displayDetailsOnIncompleteTests="true"
-        displayDetailsOnSkippedTests="true"
-        displayDetailsOnTestsThatTriggerDeprecations="true"
-        displayDetailsOnTestsThatTriggerWarnings="true"
-        displayDetailsOnTestsThatTriggerNotices="true"
-        displayDetailsOnTestsThatTriggerErrors="true"
-        defaultTestSuite="unit">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+    colors="true"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    defaultTestSuite="unit">
     <testsuites>
         <testsuite name="unit">
             <directory>test/unit/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src/</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/AllureAdapter.php
+++ b/src/AllureAdapter.php
@@ -48,21 +48,25 @@ final class AllureAdapter implements AllureAdapterInterface
         self::$instance = null;
     }
 
+    #[\Override]
     public function resetLastException(): void
     {
         $this->lastException = null;
     }
 
+    #[\Override]
     public function setLastException(Throwable $e): void
     {
         $this->lastException = $e;
     }
 
+    #[\Override]
     public function getLastException(): ?Throwable
     {
         return $this->lastException;
     }
 
+    #[\Override]
     public function registerStart(ContainerResult $containerResult, TestResult $testResult, TestInfo $info): string
     {
         $this->lastStarts[$info->getTest()] = new TestStartInfo(
@@ -73,6 +77,7 @@ final class AllureAdapter implements AllureAdapterInterface
         return $testResult->getUuid();
     }
 
+    #[\Override]
     public function getContainerId(TestInfo $info): string
     {
         $startInfo = $this->lastStarts[$info->getTest()] ?? null;
@@ -81,6 +86,7 @@ final class AllureAdapter implements AllureAdapterInterface
             ?? throw new LogicException("Container not registered: {$info->getTest()}");
     }
 
+    #[\Override]
     public function getTestId(TestInfo $info): string
     {
         $startInfo = $this->lastStarts[$info->getTest()] ?? null;
@@ -89,6 +95,7 @@ final class AllureAdapter implements AllureAdapterInterface
             ?? throw new LogicException("Test not registered: {$info->getTest()}");
     }
 
+    #[\Override]
     public function registerRun(TestResult $testResult, TestInfo $info): TestRunInfo
     {
         $testCaseId = $this->buildTestCaseId($testResult, $info);

--- a/src/AllureExtension.php
+++ b/src/AllureExtension.php
@@ -90,6 +90,7 @@ final class AllureExtension implements Extension
         return [];
     }
 
+    #[\Override]
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
         $configSource = $parameters->has('config')

--- a/src/Event/TestConsideredRiskySubscriber.php
+++ b/src/Event/TestConsideredRiskySubscriber.php
@@ -17,6 +17,7 @@ final class TestConsideredRiskySubscriber implements ConsideredRiskySubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(ConsideredRisky $event): void
     {
         $test = $event->test();

--- a/src/Event/TestErroredSubscriber.php
+++ b/src/Event/TestErroredSubscriber.php
@@ -17,6 +17,7 @@ final class TestErroredSubscriber implements ErroredSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(Errored $event): void
     {
         $test = $event->test();

--- a/src/Event/TestFailedSubscriber.php
+++ b/src/Event/TestFailedSubscriber.php
@@ -17,6 +17,7 @@ final class TestFailedSubscriber implements FailedSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(Failed $event): void
     {
         $test = $event->test();

--- a/src/Event/TestFinishedSubscriber.php
+++ b/src/Event/TestFinishedSubscriber.php
@@ -16,6 +16,7 @@ final class TestFinishedSubscriber implements FinishedSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(Finished $event): void
     {
         $test = $event->test();

--- a/src/Event/TestMarkedIncompleteSubscriber.php
+++ b/src/Event/TestMarkedIncompleteSubscriber.php
@@ -17,6 +17,7 @@ final class TestMarkedIncompleteSubscriber implements MarkedIncompleteSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(MarkedIncomplete $event): void
     {
         $test = $event->test();

--- a/src/Event/TestPassedSubscriber.php
+++ b/src/Event/TestPassedSubscriber.php
@@ -17,6 +17,7 @@ final class TestPassedSubscriber implements PassedSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(Passed $event): void
     {
         $test = $event->test();

--- a/src/Event/TestPreparationStartedSubscriber.php
+++ b/src/Event/TestPreparationStartedSubscriber.php
@@ -16,6 +16,7 @@ final class TestPreparationStartedSubscriber implements PreparationStartedSubscr
     ) {
     }
 
+    #[\Override]
     public function notify(PreparationStarted $event): void
     {
         $test = $event->test();

--- a/src/Event/TestPreparedSubscriber.php
+++ b/src/Event/TestPreparedSubscriber.php
@@ -16,6 +16,7 @@ final class TestPreparedSubscriber implements PreparedSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(Prepared $event): void
     {
         $test = $event->test();

--- a/src/Event/TestSkippedSubscriber.php
+++ b/src/Event/TestSkippedSubscriber.php
@@ -17,6 +17,7 @@ final class TestSkippedSubscriber implements SkippedSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(Skipped $event): void
     {
         $test = $event->test();

--- a/src/Event/TestWarningTriggeredSubscriber.php
+++ b/src/Event/TestWarningTriggeredSubscriber.php
@@ -17,6 +17,7 @@ final class TestWarningTriggeredSubscriber implements WarningTriggeredSubscriber
     ) {
     }
 
+    #[\Override]
     public function notify(WarningTriggered $event): void
     {
         $test = $event->test();

--- a/src/Internal/Config.php
+++ b/src/Internal/Config.php
@@ -23,6 +23,7 @@ final class Config implements ConfigInterface
     ) {
     }
 
+    #[\Override]
     public function getOutputDirectory(): ?string
     {
         $key = 'outputDirectory';
@@ -41,6 +42,7 @@ final class Config implements ConfigInterface
     /**
      * @return array<string, LinkTemplateInterface>
      */
+    #[\Override]
     public function getLinkTemplates(): array
     {
         $key = 'linkTemplates';
@@ -112,6 +114,7 @@ final class Config implements ConfigInterface
         return is_string($source) && class_exists($source);
     }
 
+    #[\Override]
     public function getSetupHook(): ?callable
     {
         $key = 'setupHook';
@@ -135,6 +138,7 @@ final class Config implements ConfigInterface
         };
     }
 
+    #[\Override]
     public function getThreadDetector(): ?ThreadDetectorInterface
     {
         $key = 'threadDetector';
@@ -149,6 +153,7 @@ final class Config implements ConfigInterface
     /**
      * @return list<LifecycleHookInterface>
      */
+    #[\Override]
     public function getLifecycleHooks(): array
     {
         $key = 'lifecycleHooks';

--- a/src/Internal/DefaultThreadDetector.php
+++ b/src/Internal/DefaultThreadDetector.php
@@ -19,6 +19,7 @@ final class DefaultThreadDetector implements ThreadDetectorInterface
 {
     private string|false|null $hostName = null;
 
+    #[\Override]
     public function getThread(): ?string
     {
         /** @var mixed $token */
@@ -29,6 +30,7 @@ final class DefaultThreadDetector implements ThreadDetectorInterface
             : null;
     }
 
+    #[\Override]
     public function getHost(): ?string
     {
         $this->hostName ??= @gethostname();

--- a/src/Internal/TestLifecycle.php
+++ b/src/Internal/TestLifecycle.php
@@ -35,6 +35,7 @@ final class TestLifecycle implements TestLifecycleInterface
     ) {
     }
 
+    #[\Override]
     public function create(): self
     {
         $containerResult = $this->resultFactory->createContainer();
@@ -48,6 +49,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function updateInfo(): self
     {
         $this->lifecycle->updateTest(
@@ -58,6 +60,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function start(): self
     {
         $this->lifecycle->startTest(
@@ -67,6 +70,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function stop(): self
     {
         $this->lifecycle->stopTest(
@@ -79,6 +83,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function updateRunInfo(): self
     {
         $this->lifecycle->updateTest(
@@ -92,6 +97,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function write(): self
     {
         $this->lifecycle->writeTest(
@@ -104,6 +110,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function updateStatus(?string $message = null, ?Status $status = null): self
     {
         $this->lifecycle->updateTest(
@@ -114,6 +121,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function updateDetectedStatus(
         ?string $message = null,
         ?Status $status = null,
@@ -137,6 +145,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function switchTo(string $test): self
     {
         $thread = $this->threadDetector->getThread();
@@ -151,6 +160,7 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function reset(): self
     {
         $this->adapter->resetLastException();

--- a/src/Internal/TestUpdater.php
+++ b/src/Internal/TestUpdater.php
@@ -23,13 +23,14 @@ use Throwable;
 /**
  * @internal
  */
-class TestUpdater implements TestUpdaterInterface
+final class TestUpdater implements TestUpdaterInterface
 {
     public function __construct(
         private readonly LinkTemplateCollectionInterface $linkTemplates,
     ) {
     }
 
+    #[\Override]
     public function setInfo(TestResult $testResult, TestInfo $info): void
     {
         $parser = $this->parseAnnotations($info);
@@ -119,6 +120,7 @@ class TestUpdater implements TestUpdaterInterface
             : [];
     }
 
+    #[\Override]
     public function setRunInfo(TestResult $testResult, TestRunInfo $runInfo): void
     {
         $testResult
@@ -127,6 +129,7 @@ class TestUpdater implements TestUpdaterInterface
             ->setRerunOf($runInfo->getRerunOf());
     }
 
+    #[\Override]
     public function setDetectedStatus(
         TestResult $test,
         StatusDetectorInterface $statusDetector,
@@ -138,6 +141,7 @@ class TestUpdater implements TestUpdaterInterface
             ->setStatusDetails($statusDetector->getStatusDetails($e));
     }
 
+    #[\Override]
     public function setStatus(TestResult $test, ?string $message = null, ?Status $status = null): void
     {
         $test

--- a/test/report/Generate/Annotation/TitleClassLevelLegacyTest.php
+++ b/test/report/Generate/Annotation/TitleClassLevelLegacyTest.php
@@ -15,7 +15,7 @@ use Yandex\Allure\Adapter\Annotation\Title;
     Attribute\Epic('Annotations'),
     Attribute\Feature('Title'),
 ]
-class TitleClassLevelLegacyTest extends TestCase
+final class TitleClassLevelLegacyTest extends TestCase
 {
     public function testWithoutTitleAnnotation(): void
     {

--- a/test/report/Generate/Annotation/TitleClassLevelMixedTest.php
+++ b/test/report/Generate/Annotation/TitleClassLevelMixedTest.php
@@ -16,7 +16,7 @@ use Yandex\Allure\Adapter\Annotation\Title;
     Attribute\Epic('Annotations'),
     Attribute\Feature('Title'),
 ]
-class TitleClassLevelMixedTest extends TestCase
+final class TitleClassLevelMixedTest extends TestCase
 {
     public function testWithoutTitleAnnotation(): void
     {

--- a/test/report/Generate/Annotation/TitleClassLevelNativeTest.php
+++ b/test/report/Generate/Annotation/TitleClassLevelNativeTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\Attribute;
     Attribute\Epic('Annotations'),
     Attribute\Feature('Title'),
 ]
-class TitleClassLevelNativeTest extends TestCase
+final class TitleClassLevelNativeTest extends TestCase
 {
     public function testWithoutTitleAnnotation(): void
     {

--- a/test/report/Generate/Annotation/TitleTest.php
+++ b/test/report/Generate/Annotation/TitleTest.php
@@ -13,7 +13,7 @@ use Yandex\Allure\Adapter\Annotation\Title;
     Attribute\Epic('Annotations'),
     Attribute\Feature('Title'),
 ]
-class TitleTest extends TestCase
+final class TitleTest extends TestCase
 {
     use ExceptionDetailsTrait;
 

--- a/test/report/Generate/AnnotationTest.php
+++ b/test/report/Generate/AnnotationTest.php
@@ -15,7 +15,7 @@ use Yandex\Allure\Adapter\Model\DescriptionType;
 use Yandex\Allure\Adapter\Model\ParameterKind;
 use Yandex\Allure\Adapter\Model\SeverityLevel;
 
-class AnnotationTest extends TestCase
+final class AnnotationTest extends TestCase
 {
     /**
      * @Description ("Legacy description with `markdown`", type = DescriptionType::MARKDOWN)

--- a/test/report/Generate/DataProviderTest.php
+++ b/test/report/Generate/DataProviderTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Qameta\Allure\Allure;
 use Qameta\Allure\Attribute\DisplayName;
 
-class DataProviderTest extends TestCase
+final class DataProviderTest extends TestCase
 {
     #[DataProvider('providerNamed'), DisplayName('Test with named data set')]
     public function testNamedDataSet(int $x, int $y): void

--- a/test/report/Generate/NegativeTest.php
+++ b/test/report/Generate/NegativeTest.php
@@ -15,7 +15,7 @@ use function trigger_error;
 
 use const E_USER_WARNING;
 
-class NegativeTest extends TestCase
+final class NegativeTest extends TestCase
 {
     use ExceptionDetailsTrait;
 

--- a/test/report/Hook/OnLifecycleErrorHook.php
+++ b/test/report/Hook/OnLifecycleErrorHook.php
@@ -12,6 +12,7 @@ final class OnLifecycleErrorHook implements OnLifecycleErrorHookInterface
     /**
      * @throws Throwable
      */
+    #[\Override]
     public function onLifecycleError(Throwable $error): void
     {
         throw $error;

--- a/test/unit/AllureAdapterTest.php
+++ b/test/unit/AllureAdapterTest.php
@@ -21,8 +21,9 @@ use function array_keys;
 use function array_map;
 
 #[CoversClass(AllureAdapter::class)]
-class AllureAdapterTest extends TestCase
+final class AllureAdapterTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         AllureAdapter::reset();

--- a/test/unit/Event/EventTestTrait.php
+++ b/test/unit/Event/EventTestTrait.php
@@ -48,14 +48,14 @@ trait EventTestTrait
                 0,
                 0,
                 0,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                false,
+                false,
+                false,
+                0,
             )
             : null; // early PHPUnit 10
 

--- a/test/unit/Event/TestConsideredRiskySubscriberTest.php
+++ b/test/unit/Event/TestConsideredRiskySubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestConsideredRiskySubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestConsideredRiskySubscriber::class)]
-class TestConsideredRiskySubscriberTest extends TestCase
+final class TestConsideredRiskySubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestErroredSubscriberTest.php
+++ b/test/unit/Event/TestErroredSubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestErroredSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestErroredSubscriber::class)]
-class TestErroredSubscriberTest extends TestCase
+final class TestErroredSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestFailedSubscriberTest.php
+++ b/test/unit/Event/TestFailedSubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestFailedSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestFailedSubscriber::class)]
-class TestFailedSubscriberTest extends TestCase
+final class TestFailedSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestFinishedSubscriberTest.php
+++ b/test/unit/Event/TestFinishedSubscriberTest.php
@@ -11,7 +11,7 @@ use Qameta\Allure\PHPUnit\Event\TestFinishedSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestFinishedSubscriber::class)]
-class TestFinishedSubscriberTest extends TestCase
+final class TestFinishedSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestMarkedIncompleteSubscriberTest.php
+++ b/test/unit/Event/TestMarkedIncompleteSubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestMarkedIncompleteSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestMarkedIncompleteSubscriber::class)]
-class TestMarkedIncompleteSubscriberTest extends TestCase
+final class TestMarkedIncompleteSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestPassedSubscriberTest.php
+++ b/test/unit/Event/TestPassedSubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestPassedSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestPassedSubscriber::class)]
-class TestPassedSubscriberTest extends TestCase
+final class TestPassedSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestPreparationStartedSubscriberTest.php
+++ b/test/unit/Event/TestPreparationStartedSubscriberTest.php
@@ -11,7 +11,7 @@ use Qameta\Allure\PHPUnit\Event\TestPreparationStartedSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestPreparationStartedSubscriber::class)]
-class TestPreparationStartedSubscriberTest extends TestCase
+final class TestPreparationStartedSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestPreparedSubscriberTest.php
+++ b/test/unit/Event/TestPreparedSubscriberTest.php
@@ -11,7 +11,7 @@ use Qameta\Allure\PHPUnit\Event\TestPreparedSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestPreparedSubscriber::class)]
-class TestPreparedSubscriberTest extends TestCase
+final class TestPreparedSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestSkippedSubscriberTest.php
+++ b/test/unit/Event/TestSkippedSubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestSkippedSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestSkippedSubscriber::class)]
-class TestSkippedSubscriberTest extends TestCase
+final class TestSkippedSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/Event/TestWarningTriggeredSubscriberTest.php
+++ b/test/unit/Event/TestWarningTriggeredSubscriberTest.php
@@ -12,7 +12,7 @@ use Qameta\Allure\PHPUnit\Event\TestWarningTriggeredSubscriber;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 #[CoversClass(TestWarningTriggeredSubscriber::class)]
-class TestWarningTriggeredSubscriberTest extends TestCase
+final class TestWarningTriggeredSubscriberTest extends TestCase
 {
     use EventTestTrait;
 

--- a/test/unit/ExceptionDetailsTraitTest.php
+++ b/test/unit/ExceptionDetailsTraitTest.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Qameta\Allure\PHPUnit\Test\Unit;
 
 use Exception;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Qameta\Allure\PHPUnit\ExceptionDetailsTrait;
 use Qameta\Allure\PHPUnit\AllureAdapter;
 use Qameta\Allure\PHPUnit\AllureAdapterInterface;
 use Throwable;
 
-#[CoversClass(ExceptionDetailsTrait::class)]
-class ExceptionDetailsTraitTest extends TestCase
+// #[CoversTrait(ExceptionDetailsTrait::class)]  <--- needed by phpunit 12
+// #[CoversClass(ExceptionDetailsTrait::class)]  <--- needed by phpunit 10 + 11
+final class ExceptionDetailsTraitTest extends TestCase
 {
     public function testOnNotSuccessfulTest_GivenException_ThrowsSameException(): void
     {

--- a/test/unit/Internal/ConfigTest.php
+++ b/test/unit/Internal/ConfigTest.php
@@ -16,7 +16,7 @@ use RuntimeException;
 use stdClass;
 
 #[CoversClass(Config::class)]
-class ConfigTest extends TestCase
+final class ConfigTest extends TestCase
 {
     #[DataProvider('providerNoOutputDirectory')]
     public function testGetOutputDirectory_EmptyData_ReturnsNull(array $data): void

--- a/test/unit/Internal/DefaultThreadDetectorTest.php
+++ b/test/unit/Internal/DefaultThreadDetectorTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Qameta\Allure\PHPUnit\Internal\DefaultThreadDetector;
 
 #[CoversClass(DefaultThreadDetector::class)]
-class DefaultThreadDetectorTest extends TestCase
+final class DefaultThreadDetectorTest extends TestCase
 {
     public function testGetThread_WithoutParatestToken_ReturnsNull(): void
     {

--- a/test/unit/Internal/TestInfoTest.php
+++ b/test/unit/Internal/TestInfoTest.php
@@ -11,7 +11,7 @@ use Qameta\Allure\PHPUnit\Internal\TestInfo;
 use stdClass;
 
 #[CoversClass(TestInfo::class)]
-class TestInfoTest extends TestCase
+final class TestInfoTest extends TestCase
 {
     public function testGetTest_ConstructedWithTest_ReturnsSameValue(): void
     {

--- a/test/unit/Internal/TestLinkTemplate.php
+++ b/test/unit/Internal/TestLinkTemplate.php
@@ -8,6 +8,7 @@ use Qameta\Allure\Setup\LinkTemplateInterface;
 
 final class TestLinkTemplate implements LinkTemplateInterface
 {
+    #[\Override]
     public function buildUrl(?string $name): ?string
     {
         return null;

--- a/test/unit/Internal/TestRunInfoTest.php
+++ b/test/unit/Internal/TestRunInfoTest.php
@@ -11,7 +11,7 @@ use Qameta\Allure\PHPUnit\Internal\TestInfo;
 use Qameta\Allure\PHPUnit\Internal\TestRunInfo;
 
 #[CoversClass(TestRunInfo::class)]
-class TestRunInfoTest extends TestCase
+final class TestRunInfoTest extends TestCase
 {
     public function testGetTestInfo_ConstructedWithTestInfo_ReturnsSameInstance(): void
     {

--- a/test/unit/Internal/TestStartInfoTest.php
+++ b/test/unit/Internal/TestStartInfoTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Qameta\Allure\PHPUnit\Internal\TestStartInfo;
 
 #[CoversClass(TestStartInfo::class)]
-class TestStartInfoTest extends TestCase
+final class TestStartInfoTest extends TestCase
 {
     public function testGetContainerId_ConstructedWithContainerId_ReturnsSameId(): void
     {

--- a/test/unit/Internal/TestThreadDetector.php
+++ b/test/unit/Internal/TestThreadDetector.php
@@ -8,11 +8,13 @@ use Qameta\Allure\PHPUnit\Setup\ThreadDetectorInterface;
 
 final class TestThreadDetector implements ThreadDetectorInterface
 {
+    #[\Override]
     public function getHost(): ?string
     {
         return null;
     }
 
+    #[\Override]
     public function getThread(): ?string
     {
         return null;

--- a/test/unit/TestTestLifecycle.php
+++ b/test/unit/TestTestLifecycle.php
@@ -9,31 +9,37 @@ use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
 final class TestTestLifecycle implements TestLifecycleInterface
 {
+    #[\Override]
     public function create(): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function reset(): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function start(): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function stop(): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function switchTo(string $test): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function updateDetectedStatus(
         ?string $message = null,
         ?Status $status = null,
@@ -42,21 +48,25 @@ final class TestTestLifecycle implements TestLifecycleInterface
         return $this;
     }
 
+    #[\Override]
     public function updateInfo(): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function updateRunInfo(): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function updateStatus(?string $message = null, ?Status $status = null): TestLifecycleInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function write(): TestLifecycleInterface
     {
         return $this;


### PR DESCRIPTION
This PR is based on PR #114  (`Fix ci pipeline`) and therefore includes the same fixes as that

Psalm drives alot of conflicting packages into this one, so the conflict section in `composer.json` is growing

Code coverage hint for `ExceptionDetailsTraitTest` has been removed as I can't get it to work with both php 8.1 -> 8.4
```php
// #[CoversTrait(ExceptionDetailsTrait::class)]  <--- needed by phpunit 12
// #[CoversClass(ExceptionDetailsTrait::class)]  <--- needed by phpunit 10 + 11
final class ExceptionDetailsTraitTest extends TestCase
```

Psalm upgraded to latest version and fixes applied to code base
