### PR TITLE
Improve testing against PHPUnit version 10, 11, and 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,6 @@ jobs:
         prefer-lowest:
           - ""
           - "--prefer-lowest"
-        include:
-          # PHPUnit ^10.5.32 is incompatible with paratest 7.3.
-          # Paratest 7.4.6, which fixes the incompatibility, requires PHP 8.2
-          - php-version: "8.1"
-            phpunit-version: "10"
-            update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
         exclude:
           # PHPUnit ^11 requires PHP 8.2
           - phpunit-version: "11"
@@ -48,6 +42,12 @@ jobs:
             php-version: "8.1"
           - phpunit-version: "12"
             php-version: "8.2"
+        include:
+          # PHPUnit ^10.5.32 is incompatible with paratest 7.3.
+          # Paratest 7.4.6, which fixes the incompatibility, requires PHP 8.2
+          - php-version: "8.1"
+            phpunit-version: "10"
+            update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,22 +71,27 @@ jobs:
           ${{ matrix.update-constraints }}
 
       - name: Set PHPUnit schema version
-        id: phpunit-version
+        id: set-phpunit-version
         run: |
-          echo "PHPUNIT_SCHEMA_VERSION=$(composer print-phpunit-schema-version)" >> $GITHUB_OUTPUT
+          echo "PHPUNIT_SCHEMA_VERSION=$(composer print-phpunit-schema-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Show PHPUnit schema version
+        id: show-phpunit-version
+        run: |
+          echo "PHPUNIT_SCHEMA_VERSION=${{ steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION }}"
 
       - name: Run tests
-        if: ${{ matrix.os != 'windows-latest' && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}
+        if: ${{ matrix.os != 'windows-latest' && steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}
         run: composer test
 
       - name: Run tests (phpunit10.0)
-        if: ${{ matrix.os != 'windows-latest' && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION == '10.0' }}
+        if: ${{ matrix.os != 'windows-latest' && steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION == '10.0' }}
         run: composer test-phpunit10.0
 
       - name: Run tests (windows)
-        if: ${{ matrix.os == 'windows-latest'  && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}
+        if: ${{ matrix.os == 'windows-latest'  && steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}
         run: composer test-windows
 
       - name: Run tests (windows-phpunit10.0)
-        if: ${{ matrix.os == 'windows-latest'  && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION == '10.0' }}
+        if: ${{ matrix.os == 'windows-latest'  && steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION == '10.0' }}
         run: composer test-windows-phpunit10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,16 +71,12 @@ jobs:
           ${{ matrix.update-constraints }}
         shell: bash
 
-      - name: Set PHPUnit schema version
+      - name: Set PHPUnit version
         id: set-phpunit-version
         run: |
+          echo "Tested against PHPUnit **v$(composer print-phpunit-version)**" >> "$GITHUB_STEP_SUMMARY"
           echo "PHPUNIT_SCHEMA_VERSION=$(composer print-phpunit-schema-version)" >> "$GITHUB_OUTPUT"
         shell: bash
-
-      - name: Show PHPUnit schema version
-        id: show-phpunit-version
-        run: |
-          echo "PHPUNIT_SCHEMA_VERSION=${{ steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION }}"
 
       - name: Run tests
         if: ${{ matrix.os != 'windows-latest' && steps.set-phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,11 @@ jobs:
           - php-version: "8.1"
             phpunit-version: "10"
             update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
+
+          # PHPUnit ~11.0 || ~11.1 can't double readonly classes, which fails some tests
+          # We constraint PHPUnit 11 to ^11.2 until we find a better solution
+          - phpunit-version: "11"
+            update-constraints: "'--with=phpunit/phpunit:^11.2'"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,12 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer update
-          --prefer-dist
-          --no-progress
+        run: >
+          composer update --prefer-dist --no-progress
           ${{ matrix.prefer-lowest }}
+          '--with=phpunit/phpunit:^${{ matrix.phpunit-version }}'
           ${{ matrix.update-constraints }}
+        shell: bash
 
       - name: Set PHPUnit schema version
         id: set-phpunit-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php-version }} on ${{ matrix.os }} (${{ matrix.composer-options }})
+    name: PHP ${{ matrix.php-version }} on ${{ matrix.os }} (${{ matrix.prefer-lowest }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,9 +25,15 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        composer-options:
+        prefer-lowest:
           - ""
           - "--prefer-lowest"
+        include:
+          # PHPUnit ^10.5.32 is incompatible with paratest 7.3.
+          # Paratest 7.4.6, which fixes the incompatibility, requires PHP 8.2
+          - php-version: "8.1"
+            prefer-lowest: ""
+            update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +53,8 @@ jobs:
         run: composer update
           --prefer-dist
           --no-progress
-          ${{ matrix.composer-options }}
+          ${{ matrix.prefer-lowest }}
+          ${{ matrix.update-constraints }}
 
       - name: Set PHPUnit schema version
         id: phpunit-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php-version }} on ${{ matrix.os }} (${{ matrix.prefer-lowest }})
+    name: PHP ${{ matrix.php-version }} PHPUnit ${{matrix.phpunit-version}} on ${{ matrix.os }} (${{ matrix.prefer-lowest }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,6 +25,10 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
+        phpunit-version:
+          - "10"
+          - "11"
+          - "12"
         prefer-lowest:
           - ""
           - "--prefer-lowest"
@@ -32,8 +36,18 @@ jobs:
           # PHPUnit ^10.5.32 is incompatible with paratest 7.3.
           # Paratest 7.4.6, which fixes the incompatibility, requires PHP 8.2
           - php-version: "8.1"
-            prefer-lowest: ""
+            phpunit-version: "10"
             update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
+        exclude:
+          # PHPUnit ^11 requires PHP 8.2
+          - phpunit-version: "11"
+            php-version: "8.1"
+
+          # PHPUnit ^12 requires PHP 8.3
+          - phpunit-version: "12"
+            php-version: "8.1"
+          - phpunit-version: "12"
+            php-version: "8.2"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,18 +49,23 @@ jobs:
           --no-progress
           ${{ matrix.composer-options }}
 
+      - name: Set PHPUnit schema version
+        id: phpunit-version
+        run: |
+          echo "PHPUNIT_SCHEMA_VERSION=$(composer print-phpunit-schema-version)" >> $GITHUB_OUTPUT
+
       - name: Run tests
-        if: ${{ matrix.os != 'windows-latest' && !contains(matrix.composer-options, '--prefer-lowest') }}
+        if: ${{ matrix.os != 'windows-latest' && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}
         run: composer test
 
       - name: Run tests (phpunit10.0)
-        if: ${{ matrix.os != 'windows-latest' && contains(matrix.composer-options, '--prefer-lowest') }}
+        if: ${{ matrix.os != 'windows-latest' && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION == '10.0' }}
         run: composer test-phpunit10.0
 
       - name: Run tests (windows)
-        if: ${{ matrix.os == 'windows-latest'  && !contains(matrix.composer-options, '--prefer-lowest') }}
+        if: ${{ matrix.os == 'windows-latest'  && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION != '10.0' }}
         run: composer test-windows
 
       - name: Run tests (windows-phpunit10.0)
-        if: ${{ matrix.os == 'windows-latest'  && contains(matrix.composer-options, '--prefer-lowest') }}
+        if: ${{ matrix.os == 'windows-latest'  && steps.phpunit-version.outputs.PHPUNIT_SCHEMA_VERSION == '10.0' }}
         run: composer test-windows-phpunit10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' && !contains(matrix.composer-options, '--prefer-lowest') }}
         run: composer test
 
-      - name: Run tests (lowest)
+      - name: Run tests (phpunit10.0)
         if: ${{ matrix.os != 'windows-latest' && contains(matrix.composer-options, '--prefer-lowest') }}
-        run: composer test-lowest
+        run: composer test-phpunit10.0
 
       - name: Run tests (windows)
         if: ${{ matrix.os == 'windows-latest'  && !contains(matrix.composer-options, '--prefer-lowest') }}
         run: composer test-windows
 
-      - name: Run tests (windows-lowest)
+      - name: Run tests (windows-phpunit10.0)
         if: ${{ matrix.os == 'windows-latest'  && contains(matrix.composer-options, '--prefer-lowest') }}
-        run: composer test-windows-lowest
+        run: composer test-windows-phpunit10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
         id: set-phpunit-version
         run: |
           echo "PHPUNIT_SCHEMA_VERSION=$(composer print-phpunit-schema-version)" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Show PHPUnit schema version
         id: show-phpunit-version

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "brianium/paratest": "^7.3",
     "psalm/plugin-phpunit": "^0.19.3",
     "squizlabs/php_codesniffer": "^3.7.2",
-    "vimeo/psalm": "^6.9"
+    "vimeo/psalm": "^6.10"
   },
   "conflict": {
     "amphp/byte-stream": "<1.5.1",

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
     "phpunit/phpunit": "^10.0.5 || ^11 || ^12"
   },
   "require-dev": {
-    "phpunit/phpunit": "~10.4.0 || ^11 || ^12",
-    "brianium/paratest": "^7.3",
+    "brianium/paratest": "^7",
     "psalm/plugin-phpunit": "^0.19.5",
     "squizlabs/php_codesniffer": "^3.7.2",
     "vimeo/psalm": "^6.10"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
     "allure-framework/allure-php-commons": "^2.0",
-    "phpunit/phpunit": "^10 || ^11 || ^12"
+    "phpunit/phpunit": "^10.0.5 || ^11 || ^12"
   },
   "require-dev": {
     "phpunit/phpunit": "~10.4.0 || ^11 || ^12",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "require-dev": {
     "phpunit/phpunit": "~10.4.0 || ^11 || ^12",
     "brianium/paratest": "^7.3",
-    "psalm/plugin-phpunit": "^0.19.3",
+    "psalm/plugin-phpunit": "^0.19.5",
     "squizlabs/php_codesniffer": "^3.7.2",
     "vimeo/psalm": "^6.10"
   },

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,9 @@
       "@test-report-windows-phpunit10.0",
       "@test-psalm"
     ],
+    "print-phpunit-version": [
+      "Qameta\\Allure\\PHPUnit\\Scripts\\CiScripts::printPhpUnitVersion"
+    ],
     "print-phpunit-schema-version": [
       "Qameta\\Allure\\PHPUnit\\Scripts\\CiScripts::printConfigSchemaVersion"
     ]

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
     },
     "psr-4": {
       "Qameta\\Allure\\PHPUnit\\Test\\Unit\\": "test/unit/",
-      "Qameta\\Allure\\PHPUnit\\Test\\Report\\": "test/report/"
+      "Qameta\\Allure\\PHPUnit\\Test\\Report\\": "test/report/",
+      "Qameta\\Allure\\PHPUnit\\Scripts\\": "scripts/"
     }
   },
   "scripts": {
@@ -115,6 +116,9 @@
       "@test-unit-lowest",
       "@test-report-windows-lowest",
       "@test-psalm"
+    ],
+    "print-phpunit-schema-version": [
+      "Qameta\\Allure\\PHPUnit\\Scripts\\CiScripts::printConfigSchemaVersion"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
     "allure-framework/allure-php-commons": "^2.0",
-    "phpunit/phpunit": "^10.0.5 || ^11 || ^12"
+    "phpunit/phpunit": "^10.0.5 || ^11 || ^12.0.1"
   },
   "require-dev": {
     "brianium/paratest": "^7",

--- a/composer.json
+++ b/composer.json
@@ -69,14 +69,14 @@
   "scripts": {
     "test-cs": "vendor/bin/phpcs -sp",
     "test-unit": "vendor/bin/phpunit --coverage-text",
-    "test-unit-lowest": "vendor/bin/phpunit --configuration=phpunit.10.0.xml --coverage-text",
+    "test-unit-phpunit10.0": "vendor/bin/phpunit --configuration=phpunit.10.0.xml --coverage-text",
     "clear-allure-results": "rm -rf ./build/allure-results",
     "test-report": [
       "@clear-allure-results",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.report.xml --testsuite=positive",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.report.xml --testsuite=negative; exit 0"
     ],
-    "test-report-lowest": [
+    "test-report-phpunit10.0": [
       "@clear-allure-results",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.10.0.report.xml --testsuite=positive",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.10.0.report.xml --testsuite=negative; exit 0"
@@ -86,7 +86,7 @@
       "vendor/bin/paratest --processes=3 --configuration=phpunit.report.xml --testsuite=positive",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.report.xml --testsuite=negative & exit 0"
     ],
-    "test-report-windows-lowest": [
+    "test-report-windows-phpunit10.0": [
       "@clear-allure-results",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.10.0.report.xml --testsuite=positive",
       "vendor/bin/paratest --processes=3 --configuration=phpunit.10.0.report.xml --testsuite=negative & exit 0"
@@ -98,10 +98,10 @@
       "@test-report",
       "@test-psalm"
     ],
-    "test-lowest": [
+    "test-phpunit10.0": [
       "@test-cs",
-      "@test-unit-lowest",
-      "@test-report-lowest",
+      "@test-unit-phpunit10.0",
+      "@test-report-phpunit10.0",
       "@test-psalm"
     ],
     "test-windows": [
@@ -110,10 +110,10 @@
       "@test-report-windows",
       "@test-psalm"
     ],
-    "test-windows-lowest": [
+    "test-windows-phpunit10.0": [
       "@test-cs",
-      "@test-unit-lowest",
-      "@test-report-windows-lowest",
+      "@test-unit-phpunit10.0",
+      "@test-report-windows-phpunit10.0",
       "@test-psalm"
     ],
     "print-phpunit-schema-version": [

--- a/phpunit.10.0.xml
+++ b/phpunit.10.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     colors="true"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"
@@ -15,9 +15,9 @@
             <directory>test/unit/</directory>
         </testsuite>
     </testsuites>
-    <source>
+    <coverage>
         <include>
             <directory suffix=".php">src/</directory>
         </include>
-    </source>
+    </coverage>
 </phpunit>

--- a/phpunit.report.xml
+++ b/phpunit.report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
         colors="true"
         displayDetailsOnIncompleteTests="true"
         displayDetailsOnSkippedTests="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
         colors="true"
         displayDetailsOnIncompleteTests="true"
         displayDetailsOnSkippedTests="true"

--- a/scripts/CiScripts.php
+++ b/scripts/CiScripts.php
@@ -5,6 +5,16 @@ namespace Qameta\Allure\PHPUnit\Scripts;
 final class CiScripts
 {
     /**
+     * Prints the version of PHPUnit.
+     */
+    public static function printPhpUnitVersion(): void
+    {
+        if (class_exists(\PHPUnit\Runner\Version::class)) {
+            echo(\PHPUnit\Runner\Version::id());
+        }
+    }
+
+    /**
      * Prints the version of the PHPUnit XML schema.
      * We use this in the CI pipeline to deside which configuration file to use.
      */

--- a/scripts/CiScripts.php
+++ b/scripts/CiScripts.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Qameta\Allure\PHPUnit\Scripts;
+
+final class CiScripts
+{
+    /**
+     * Prints the version of the PHPUnit XML schema.
+     * We use this in the CI pipeline to deside which configuration file to use.
+     */
+    public static function printConfigSchemaVersion(): void
+    {
+        if (class_exists(\PHPUnit\Runner\Version::class)) {
+            echo(preg_replace('/^(\d+\.\d+)\..*$/', '$1', \PHPUnit\Runner\Version::id()));
+        }
+    }
+}

--- a/test/report/Generate/DataProviderTest.php
+++ b/test/report/Generate/DataProviderTest.php
@@ -17,6 +17,9 @@ final class DataProviderTest extends TestCase
         Allure::runStep(fn () => self::assertSame($x, $y));
     }
 
+    /**
+     * @return iterable<string, array<int, int>>
+     */
     public static function providerNamed(): iterable
     {
         return [
@@ -34,6 +37,9 @@ final class DataProviderTest extends TestCase
         Allure::runStep(fn () => self::assertSame($x, $y));
     }
 
+    /**
+     * @return iterable<int, array<int, int>>
+     */
     public static function providerListed(): iterable
     {
         return [

--- a/test/unit/Event/EventTestTrait.php
+++ b/test/unit/Event/EventTestTrait.php
@@ -246,6 +246,10 @@ trait EventTestTrait
         );
     }
 
+    /**
+     * GarbageCollectorStatus doesn't exist in PHPUnit 10.0
+     * @psalm-suppress UndefinedClass
+     */
     private static function createGarbageCollectorStatus(): ?GarbageCollectorStatus
     {
         // GarbageCollectorStatus doesn't exist in PHPUnit 10.0

--- a/test/unit/Event/EventTestTrait.php
+++ b/test/unit/Event/EventTestTrait.php
@@ -38,26 +38,7 @@ trait EventTestTrait
 {
     protected function createTelemetryInfo(): Info
     {
-        /**
-         * @psalm-suppress MixedAssignment
-         * @psalm-suppress TooManyArguments
-         */
-        $garbageCollectorStatus = class_exists(GarbageCollectorStatus::class)
-            ? new GarbageCollectorStatus(
-                0,
-                0,
-                0,
-                0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                false,
-                false,
-                false,
-                0,
-            )
-            : null; // early PHPUnit 10
+        $garbageCollectorStatus = self::createGarbageCollectorStatus();
 
         /**
          * @psalm-suppress TooManyArguments
@@ -263,5 +244,48 @@ trait EventTestTrait
             false,
             false,
         );
+    }
+
+    private static function createGarbageCollectorStatus(): ?GarbageCollectorStatus
+    {
+        // GarbageCollectorStatus doesn't exist in PHPUnit 10.0
+        if (class_exists(GarbageCollectorStatus::class)) {
+            $ctorInfo = (new \ReflectionClass(GarbageCollectorStatus::class))->getConstructor();
+            if (isset($ctorInfo)) {
+                /**
+                 * @psalm-suppress InvalidArgument
+                 * @psalm-suppress TooFewArguments
+                 * @psalm-suppress TooManyArguments
+                 */
+                return $ctorInfo->getNumberOfParameters() === 8
+                    # PHPUnit [10.1, 10.3)
+                    ? new GarbageCollectorStatus(
+                        0,
+                        0,
+                        0,
+                        0,
+                        false,
+                        false,
+                        false,
+                        0,
+                    )
+                    # Extra arguments are required since 10.3.0
+                    : new GarbageCollectorStatus(
+                        0,
+                        0,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        false,
+                        false,
+                        false,
+                        0,
+                    );
+            }
+        }
+        return null;
     }
 }

--- a/test/unit/ExceptionDetailsTraitTest.php
+++ b/test/unit/ExceptionDetailsTraitTest.php
@@ -52,15 +52,18 @@ abstract class ExceptionDetailsTraitTestBase extends TestCase
     }
 }
 
+/**
+ * CoversTrait was added in PHPUnit 11.2.0.
+ * If was then deprecated in 11.4.0 but the deprecation was reverted in 11.5.4.
+ * @psalm-suppress DeprecatedClass
+ */
 if (class_exists(CoversTrait::class)) {
-    // Since PHPUnit 11.2.0 (deprecation has been reverted in 11.5.4)
     #[CoversTrait(ExceptionDetailsTrait::class)]
     final class ExceptionDetailsTraitTest extends ExceptionDetailsTraitTestBase
     {
     }
 
 } else {
-    // For PHPUnit <11.2.0
     #[CoversClass(ExceptionDetailsTrait::class)]
     final class ExceptionDetailsTraitTest extends ExceptionDetailsTraitTestBase
     {

--- a/test/unit/ExceptionDetailsTraitTest.php
+++ b/test/unit/ExceptionDetailsTraitTest.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\PHPUnit\Test\Unit;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
+
 use Exception;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use Qameta\Allure\PHPUnit\ExceptionDetailsTrait;
 use Qameta\Allure\PHPUnit\AllureAdapter;
 use Qameta\Allure\PHPUnit\AllureAdapterInterface;
 use Throwable;
 
-// #[CoversTrait(ExceptionDetailsTrait::class)]  <--- needed by phpunit 12
-// #[CoversClass(ExceptionDetailsTrait::class)]  <--- needed by phpunit 10 + 11
-final class ExceptionDetailsTraitTest extends TestCase
+abstract class ExceptionDetailsTraitTestBase extends TestCase
 {
     public function testOnNotSuccessfulTest_GivenException_ThrowsSameException(): void
     {
@@ -48,4 +50,20 @@ final class ExceptionDetailsTraitTest extends TestCase
         } catch (Throwable) {
         }
     }
+}
+
+if (class_exists(CoversTrait::class)) {
+    // Since PHPUnit 11.2.0 (deprecation has been reverted in 11.5.4)
+    #[CoversTrait(ExceptionDetailsTrait::class)]
+    final class ExceptionDetailsTraitTest extends ExceptionDetailsTraitTestBase
+    {
+    }
+
+} else {
+    // For PHPUnit <11.2.0
+    #[CoversClass(ExceptionDetailsTrait::class)]
+    final class ExceptionDetailsTraitTest extends ExceptionDetailsTraitTestBase
+    {
+    }
+
 }


### PR DESCRIPTION
#### Context

#115 has added support for PHP 8.4 and PHPUnit 11 and 12.

This PR continues the efforts to 

  - Clarify the exact versions of the deps `allure-phpunit` requires.
  - Make sure we have a CI workflow that tests against all supported versions of PHP and PHPUnit.

#### Supported PHP versions

We support all versions currently supported by the PHP devs, see [https://www.php.net/supported-versions](https://www.php.net/supported-versions). Currently, those are `^8.1 || ^8.2 || ^8.3 || ^8.4`.

#### Supported PHPUnit versions

Currently, we aim to support PHPUnit 10, 11, and 12. Due to the requirements of `brianium/paratest` (our dev dependency), we can't install the following PHPUnit versions:

  - 10.0.0-10.0.4
  - 12.0.0

Since we use the same PHPUnit installation for running our tests and the Allure adapter for PHPUnit, we can't test against the versions above either in CI or on personal machines. If a bug is reported with one of those versions, we cannot write a test that reproduces it without tweaking the dependency spec.

With that in mind, this PR sets the declared supported versions of PHPUnit to `^10.0.5 || ^11 || ^12.0.1`.

#### PHPUnit versions in the CI matrix

Previously, we only tested against PHPUnit `^10` with and without `--prefer-lowest`.

After versions `^11` and `^12` were added to `require`, that testing scheme became incomplete: it skipped PHPUnit 11.

This PR adds a PHPUnit version dimension to the testing CI job, which enables testing against the whole range of the supported PHPUnit versions.

There are some incompatibilities between PHP, PHPUnit, and ParaTest (see `include` and `exclude` in `build.yml`).

Additionally, we have some tests that mock `PHPUnit\Event\Code\Test`, which is `readonly` starting from PHPUnit 11.0.0. Those tests fail when run with PHPUnit 11.0 and 11.1. One solution would be skipping the tests if mocking fails, but for now, the PR further constrains PHPUnit 11 to `^11.2` in the CI workflow.

The XML schema for the legacy (v10) PHPUnit config files was reverted to `https://schema.phpunit.de/10.0/phpunit.xsd`. We are now using a PHP script to get the PHPUnit version at runtime and choose the correct config file based on it.

#### `GarbageCollectorStatus` compatibility

`PHPUnit\Event\Telemetry\GarbageCollectorStatus` was introduced in PHPUnit 10.1.0. Its constructor requires four extra parameters starting from 10.3.0. The PR fixes `EventTestTrait` to account for all three cases by checking the number of constructor parameters with `ReflectionClass`.

#### `#[CoversClass]` and `#[CoversTrait]`

We use `#[CoversClass]` to indicate to PHPUnit that only `ExceptionDetailsTrait`'s methods should be marked as covered by the tests in `ExceptionDetailsTraitTest`. Using traits with `#[CoversClass]` was an undocumented (and untested) feature of PHPUnit, which became broken at some point. Then, `#[CoversTrait]` was introduced in 11.2.0, and PHPUnit's devs advised to use it with traits instead of `#[CoversClass]`.

The PR refactors `ExceptionDetailsTraitTest` to be conditionally defined with the correct attribute, which supports both old and new mechanisms depending on whether `PHPUnit\Framework\Attributes\CoversTrait` exists or not.

In 11.4.0, `#[CoversTrait]` was declared as deprecated: the devs had discovered that `#[CoversClass]` also covers the target's traits and decided the new attribute wasn't needed in the first place. They reinstated it in 11.5.4 and kept it in version 12 to target traits without targeting the surrounding class. See the discussion [here](https://github.com/sebastianbergmann/phpunit/issues/5958).

> [!NOTE]
> We are ignoring `PSR1.Classes.ClassDeclaration.MultipleClasses` in `ExceptionDetailsTraitTest.php` because it essentially declares a single class used outside.

#### Psalm fixes

The `0.19.4` release of `psalm/plugin-phpunit` has introduced new checks on data providers for PHPUnit tests. The ones we have in `DataProviderTest.php` failed them ([see here](https://github.com/allure-framework/allure-phpunit/actions/runs/14355416539)).

The PR applies the correct type annotations to the data provider functions, which fixes the issues.

#### Dependency updates

  - Remove `phpunit/phpunit` from `require-dev`.
  - Widen the supported versions of `brianium/paratest` from `^7.3` to `^7`.
  - Bump `vimeo/psalm` to `^6.10`.
  - Bump `psalm/plugin-phpunit` to `^0.19.5`.

#### PHPUnit configuration update

The PR bumps the XML schema of the default PHPUnit config files we use to `https://schema.phpunit.de/12.1/phpunit.xsd`.

Ideally, we should use a separate config file for each major PHPUnit version we test against. However, in our case, the config file is compatible with versions 11 and 12.
