### PR TITLE
Add support for PHPUnit 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           - "10"
           - "11"
           - "12"
+          - "13"
         prefer-lowest:
           - ""
           - "--prefer-lowest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php-version }} PHPUnit ${{matrix.phpunit-version}} on ${{ matrix.os }} (${{ matrix.prefer-lowest }})
+    name: PHP ${{ matrix.php-version }} PHPUnit ${{matrix.phpunit-version}} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,9 +31,7 @@ jobs:
           - "11"
           - "12"
           - "13"
-        prefer-lowest:
-          - ""
-          - "--prefer-lowest"
+
         exclude:
           # PHPUnit ^11 requires PHP 8.2
           - phpunit-version: "11"
@@ -50,6 +48,7 @@ jobs:
             php-version: "8.5"
           - phpunit-version: "11"
             php-version: "8.5"
+
         include:
           # PHPUnit ^10.5.32 is incompatible with paratest 7.3.
           # Paratest 7.4.6, which fixes the incompatibility, requires PHP 8.2
@@ -57,16 +56,6 @@ jobs:
             phpunit-version: "10"
             update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
 
-          # PHPUnit ~11.0 || ~11.1 can't double readonly classes, which fails some tests
-          # We constraint PHPUnit 11 to ^11.2 until we find a better solution
-          - phpunit-version: "11"
-            update-constraints: "'--with=phpunit/phpunit:^11.2'"
-
-          # Some dev libraries are resolved to versions incompatible with PHP 8.5
-          # under the --prefer-lowest strategy. Here we're constraining them to
-          # the lowest compatible versions.
-          - php-version: "8.5"
-            update-constraints: "'--with=amphp/amp:>=3.1.1' '--with=amphp/parallel:>=2.3.3' '--with=nikic/php-parser:>=5.7' '--with=revolt/event-loop:>=1.0.8'"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -85,7 +74,6 @@ jobs:
       - name: Install dependencies
         run: >
           composer update --prefer-dist --no-progress
-          ${{ matrix.prefer-lowest }}
           '--with=phpunit/phpunit:^${{ matrix.phpunit-version }}'
           ${{ matrix.update-constraints }}
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
           - phpunit-version: "12"
             php-version: "8.2"
 
+          # PHPUnit ^13 requires PHP 8.4
+          - phpunit-version: "13"
+            php-version: "8.1"
+          - phpunit-version: "13"
+            php-version: "8.2"
+          - phpunit-version: "13"
+            php-version: "8.3"
+
           # the lowest paratest version that supports PHP 8.5 requires PHPUnit ^12
           - phpunit-version: "10"
             php-version: "8.5"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
@@ -33,10 +32,6 @@ jobs:
           - "13"
 
         exclude:
-          # PHPUnit ^11 requires PHP 8.2
-          - phpunit-version: "11"
-            php-version: "8.1"
-
           # PHPUnit ^12 requires PHP 8.3
           - phpunit-version: "12"
             php-version: "8.1"
@@ -57,13 +52,6 @@ jobs:
           - phpunit-version: "11"
             php-version: "8.5"
 
-        include:
-          # PHPUnit ^10.5.32 is incompatible with paratest 7.3.
-          # Paratest 7.4.6, which fixes the incompatibility, requires PHP 8.2
-          - php-version: "8.1"
-            phpunit-version: "10"
-            update-constraints: "'--with=phpunit/phpunit:<10.5.32'"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -83,7 +71,6 @@ jobs:
         run: >
           composer update --prefer-dist --no-progress
           '--with=phpunit/phpunit:^${{ matrix.phpunit-version }}'
-          ${{ matrix.update-constraints }}
         shell: bash
 
       - name: Set PHPUnit version

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -8,6 +8,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: zwaldowski/match-label-action@v4
+      - uses: zwaldowski/match-label-action@v6
         with:
           allowed: 'type:bug,type:new feature,type:improvement,type:dependencies,type:internal,type:invalid'

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
     "allure-framework/allure-php-commons": "^2.0",
-    "phpunit/phpunit": "^10.0.5 || ^11 || ^12.0.1"
+    "phpunit/phpunit": "^10.0.5 || ^11 || ^12.0.1 || ^13"
   },
   "require-dev": {
     "brianium/paratest": "^7",

--- a/test/unit/Event/TestConsideredRiskySubscriberTest.php
+++ b/test/unit/Event/TestConsideredRiskySubscriberTest.php
@@ -39,19 +39,30 @@ final class TestConsideredRiskySubscriberTest extends TestCase
             message: 'c',
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateStatus')
             ->with(
                 self::identicalTo('c'),
                 self::identicalTo(Status::failed()),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateStatus() was called before switchTo()");
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }

--- a/test/unit/Event/TestErroredSubscriberTest.php
+++ b/test/unit/Event/TestErroredSubscriberTest.php
@@ -39,20 +39,32 @@ final class TestErroredSubscriberTest extends TestCase
             message: 'c',
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateDetectedStatus')
             ->with(
                 self::identicalTo('c'),
                 self::identicalTo(Status::broken()),
                 self::identicalTo(null),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateDetectedStatus() was called before switchTo()");
+
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }

--- a/test/unit/Event/TestFailedSubscriberTest.php
+++ b/test/unit/Event/TestFailedSubscriberTest.php
@@ -39,20 +39,32 @@ final class TestFailedSubscriberTest extends TestCase
             message: 'c',
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateDetectedStatus')
             ->with(
                 self::identicalTo('c'),
                 self::identicalTo(Status::failed()),
                 self::identicalTo(Status::failed()),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateDetectedStatus() was called before switchTo()");
+
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }

--- a/test/unit/Event/TestFinishedSubscriberTest.php
+++ b/test/unit/Event/TestFinishedSubscriberTest.php
@@ -37,28 +37,52 @@ final class TestFinishedSubscriberTest extends TestCase
             $this->createTestMethod(class: 'a', methodName: 'b'),
         );
 
+        $lastMethod = null;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    $lastMethod = "switchTo";
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->id('stop')
-            ->after('switch')
             ->method('stop')
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("switchTo", $lastMethod, "stop() was called before switchTo()");
+
+                    $lastMethod = "stop";
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->id('update')
-            ->after('stop')
             ->method('updateRunInfo')
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("stop", $lastMethod, "updateRunInfo() was called before stop()");
+
+                    $lastMethod = "updateRunInfo";
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('update')
-            ->method('write');
+            ->method('write')
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("updateRunInfo", $lastMethod, "write() was called before updateRunInfo()");
+
+                    return $testLifecycle;
+                }
+            );
         $subscriber->notify($event);
     }
 }

--- a/test/unit/Event/TestMarkedIncompleteSubscriberTest.php
+++ b/test/unit/Event/TestMarkedIncompleteSubscriberTest.php
@@ -39,19 +39,31 @@ final class TestMarkedIncompleteSubscriberTest extends TestCase
             message: 'c',
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateStatus')
             ->with(
                 self::identicalTo('c'),
                 self::identicalTo(Status::broken()),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateStatus() was called before switchTo()");
+
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }

--- a/test/unit/Event/TestPassedSubscriberTest.php
+++ b/test/unit/Event/TestPassedSubscriberTest.php
@@ -38,19 +38,31 @@ final class TestPassedSubscriberTest extends TestCase
             test: $this->createTestMethod(class: 'a', methodName: 'b'),
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateStatus')
             ->with(
                 self::identicalTo(null),
                 self::identicalTo(Status::passed()),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateStatus() was called before switchTo()");
+
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }

--- a/test/unit/Event/TestPreparationStartedSubscriberTest.php
+++ b/test/unit/Event/TestPreparationStartedSubscriberTest.php
@@ -37,22 +37,40 @@ final class TestPreparationStartedSubscriberTest extends TestCase
             test: $this->createTestMethod(class: 'a', methodName: 'b'),
         );
 
+        $lastMethod = null;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    $lastMethod = "switchTo";
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->id('reset')
-            ->after('switch')
             ->method('reset')
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("switchTo", $lastMethod, "reset() was called before switchTo()");
+
+                    $lastMethod = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('reset')
-            ->method('create');
+            ->method('create')
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("reset", $lastMethod, "create() was called before reset()");
+
+                    return $testLifecycle;
+                }
+            );
         $subscriber->notify($event);
     }
 }

--- a/test/unit/Event/TestPreparedSubscriberTest.php
+++ b/test/unit/Event/TestPreparedSubscriberTest.php
@@ -37,22 +37,40 @@ final class TestPreparedSubscriberTest extends TestCase
             test: $this->createTestMethod(class: 'a', methodName: 'b'),
         );
 
+        $lastMethod = null;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    $lastMethod = "switchTo";
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->id('update')
-            ->after('switch')
             ->method('updateInfo')
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("switchTo", $lastMethod, "updateInfo() was called before switchTo()");
+
+                    $lastMethod = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('update')
-            ->method('start');
+            ->method('start')
+            ->willReturnCallback(
+                function () use (&$lastMethod, $testLifecycle) {
+                    self::assertEquals("updateInfo", $lastMethod, "start() was called before updateInfo()");
+
+                    return $testLifecycle;
+                }
+            );
         $subscriber->notify($event);
     }
 }

--- a/test/unit/Event/TestSkippedSubscriberTest.php
+++ b/test/unit/Event/TestSkippedSubscriberTest.php
@@ -39,19 +39,31 @@ final class TestSkippedSubscriberTest extends TestCase
             message: 'c',
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateStatus')
             ->with(
                 self::identicalTo('c'),
                 self::identicalTo(Status::skipped()),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateStatus() was called before switchTo()");
+
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }

--- a/test/unit/Event/TestWarningTriggeredSubscriberTest.php
+++ b/test/unit/Event/TestWarningTriggeredSubscriberTest.php
@@ -39,19 +39,31 @@ final class TestWarningTriggeredSubscriberTest extends TestCase
             message: 'c',
         );
 
+        $switched = false;
         $testLifecycle
             ->expects(self::once())
-            ->id('switch')
             ->method('switchTo')
             ->with(self::identicalTo('a::b'))
-            ->willReturnSelf();
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    $switched = true;
+
+                    return $testLifecycle;
+                }
+            );
         $testLifecycle
             ->expects(self::once())
-            ->after('switch')
             ->method('updateStatus')
             ->with(
                 self::identicalTo('c'),
                 self::identicalTo(Status::broken()),
+            )
+            ->willReturnCallback(
+                function () use (&$switched, $testLifecycle) {
+                    self::assertTrue($switched, "updateStatus() was called before switchTo()");
+
+                    return $testLifecycle;
+                }
             );
         $subscriber->notify($event);
     }


### PR DESCRIPTION
The PR adds PHPUnit 13 to the list of supported versions.

#### Extra changes

  - bump `zwaldowski/match-label-action` to `v6` (moving to Node.js 24)
  - replace PHPUnit Mock id/after calls with direct checks via callbacks following the [deprecation](https://github.com/sebastianbergmann/phpunit/issues/6537)
  - give up `--prefer-lowest` dimension of the build pipeline. It created endless problems by installing the minimum required dev dependencies for a given PHP version. Once we've introduced the PHPUnit version dimension into the matrix, it contributes little to overall coverage. We're testing all current major versions, and that should be enough.
  - Remove PHP 8.1 from the build pipeline matrix. We can't test against it anymore without `--no-security-blocking`, which creates an extra attack vector we would prefer to avoid. PHP 8.1 is still supported, though. It's that we just don't test against it anymore.