### PR TITLE
Add titlePath to test result JSON files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-    "allure-framework/allure-php-commons": "^2.0",
+    "allure-framework/allure-php-commons": "^2.4",
     "phpunit/phpunit": "^10.0.5 || ^11 || ^12.0.1 || ^13"
   },
   "require-dev": {

--- a/src/Event/TestConsideredRiskySubscriber.php
+++ b/src/Event/TestConsideredRiskySubscriber.php
@@ -21,14 +21,13 @@ final class TestConsideredRiskySubscriber implements ConsideredRiskySubscriber
     public function notify(ConsideredRisky $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateStatus($event->message(), Status::failed());
     }
 }

--- a/src/Event/TestErroredSubscriber.php
+++ b/src/Event/TestErroredSubscriber.php
@@ -21,14 +21,13 @@ final class TestErroredSubscriber implements ErroredSubscriber
     public function notify(Errored $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateDetectedStatus($event->throwable()->message(), Status::broken());
     }
 }

--- a/src/Event/TestFailedSubscriber.php
+++ b/src/Event/TestFailedSubscriber.php
@@ -21,14 +21,13 @@ final class TestFailedSubscriber implements FailedSubscriber
     public function notify(Failed $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateDetectedStatus($event->throwable()->message(), Status::failed(), Status::failed());
     }
 }

--- a/src/Event/TestFinishedSubscriber.php
+++ b/src/Event/TestFinishedSubscriber.php
@@ -20,14 +20,13 @@ final class TestFinishedSubscriber implements FinishedSubscriber
     public function notify(Finished $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->stop()
             ->updateRunInfo()
             ->write();

--- a/src/Event/TestMarkedIncompleteSubscriber.php
+++ b/src/Event/TestMarkedIncompleteSubscriber.php
@@ -21,14 +21,13 @@ final class TestMarkedIncompleteSubscriber implements MarkedIncompleteSubscriber
     public function notify(MarkedIncomplete $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateStatus($event->throwable()->message(), Status::broken());
     }
 }

--- a/src/Event/TestPassedSubscriber.php
+++ b/src/Event/TestPassedSubscriber.php
@@ -21,14 +21,13 @@ final class TestPassedSubscriber implements PassedSubscriber
     public function notify(Passed $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateStatus(status: Status::passed());
     }
 }

--- a/src/Event/TestPreparationStartedSubscriber.php
+++ b/src/Event/TestPreparationStartedSubscriber.php
@@ -20,14 +20,13 @@ final class TestPreparationStartedSubscriber implements PreparationStartedSubscr
     public function notify(PreparationStarted $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->reset()
             ->create();
     }

--- a/src/Event/TestPreparedSubscriber.php
+++ b/src/Event/TestPreparedSubscriber.php
@@ -20,14 +20,13 @@ final class TestPreparedSubscriber implements PreparedSubscriber
     public function notify(Prepared $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateInfo()
             ->start();
     }

--- a/src/Event/TestSkippedSubscriber.php
+++ b/src/Event/TestSkippedSubscriber.php
@@ -21,14 +21,13 @@ final class TestSkippedSubscriber implements SkippedSubscriber
     public function notify(Skipped $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test->nameWithClass() : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method)
+            ->switchTo($test)
             ->updateStatus($event->message(), Status::skipped());
     }
 }

--- a/src/Event/TestWarningTriggeredSubscriber.php
+++ b/src/Event/TestWarningTriggeredSubscriber.php
@@ -21,14 +21,13 @@ final class TestWarningTriggeredSubscriber implements WarningTriggeredSubscriber
     public function notify(WarningTriggered $event): void
     {
         $test = $event->test();
-        $method = $test instanceof TestMethod ? $test : null;
-        if (!isset($method)) {
+        if (!$test instanceof TestMethod) {
             return;
         }
 
         $this
             ->testLifecycle
-            ->switchTo($method->nameWithClass())
+            ->switchTo($test)
             ->updateStatus($event->message(), Status::broken());
     }
 }

--- a/src/Internal/TestInfo.php
+++ b/src/Internal/TestInfo.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\PHPUnit\Internal;
 
+use function array_filter;
+use function explode;
+use function is_string;
+
 /**
  * @internal
  */
@@ -55,6 +59,16 @@ final class TestInfo
         return isset($this->class, $this->method)
             ? "{$this->class}::{$this->method}"
             : null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTitlePath(): array
+    {
+        return is_string($this->class)
+            ? [...array_filter(explode("\\", $this->class))]
+            : [];
     }
 
     public function getName(): string

--- a/src/Internal/TestLifecycle.php
+++ b/src/Internal/TestLifecycle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\PHPUnit\Internal;
 
+use PHPUnit\Event\Code\TestMethod;
 use Qameta\Allure\AllureLifecycleInterface;
 use Qameta\Allure\Model\ResultFactoryInterface;
 use Qameta\Allure\Model\Status;
@@ -16,6 +17,7 @@ use RuntimeException;
 use function array_pad;
 use function class_exists;
 use function explode;
+use function is_int;
 use function preg_match;
 
 /**
@@ -146,7 +148,7 @@ final class TestLifecycle implements TestLifecycleInterface
     }
 
     #[\Override]
-    public function switchTo(string $test): self
+    public function switchTo(TestMethod $test): self
     {
         $thread = $this->threadDetector->getThread();
         $this->lifecycle->switchThread($thread);
@@ -173,42 +175,22 @@ final class TestLifecycle implements TestLifecycleInterface
         return $this->currentTest ?? throw new RuntimeException("Current test is not set");
     }
 
-    private function buildTestInfo(string $test, ?string $host = null, ?string $thread = null): TestInfo
+    private function buildTestInfo(TestMethod $test, ?string $host = null, ?string $thread = null): TestInfo
     {
-        /** @var list<string> $matches */
-        $classAndMethodMatchResult = preg_match(
-            '#^(\S+)(.*)$#',
-            $test,
-            $matches,
-        );
-        [$classAndMethod, $dataSetInfo] = 1 === $classAndMethodMatchResult
-            ? [$matches[1] ?? null, $matches[2] ?? null]
-            : [$test, null];
-        $dataLabelMatchResult = isset($dataSetInfo)
-            ? preg_match(
-                '/^\s+with\s+data\s+set\s+(?:(#\d+)|"(.*)")$/',
-                $dataSetInfo,
-                $matches,
-            )
-            : false;
-        $dataLabel = 1 === $dataLabelMatchResult
-            ? $matches[2] ?? $matches[1] ?? null
-            : null;
-        if ('' === $dataLabel) {
-            $dataLabel = null;
-        }
+        $className = $test->className();
+        $methodName = $test->methodName();
 
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
-        [$class, $method] = isset($classAndMethod)
-            ? array_pad(explode('::', $classAndMethod, 2), 2, null)
-            : [null, null];
+        $testData = $test->testData();
+        $dataSetName = $testData->hasDataFromDataProvider()
+            ? $testData->dataFromDataProvider()->dataSetName()
+            : null;
 
         /** @psalm-suppress MixedArgument */
         return new TestInfo(
-            test: $test,
-            class: isset($class) && class_exists($class) ? $class : null,
-            method: $method,
-            dataLabel: $dataLabel,
+            test: $test->nameWithClass(),
+            class: class_exists($className) ? $className : null,
+            method: $methodName,
+            dataLabel: is_int($dataSetName) ? "#" . $dataSetName : $dataSetName,
             host: $host,
             thread: $thread,
         );

--- a/src/Internal/TestLifecycleInterface.php
+++ b/src/Internal/TestLifecycleInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\PHPUnit\Internal;
 
+use PHPUnit\Event\Code\TestMethod;
 use Qameta\Allure\Model\Status;
 
 interface TestLifecycleInterface
@@ -28,7 +29,7 @@ interface TestLifecycleInterface
         ?Status $overrideStatus = null,
     ): TestLifecycleInterface;
 
-    public function switchTo(string $test): TestLifecycleInterface;
+    public function switchTo(TestMethod $test): TestLifecycleInterface;
 
     public function reset(): TestLifecycleInterface;
 }

--- a/src/Internal/TestUpdater.php
+++ b/src/Internal/TestUpdater.php
@@ -38,6 +38,7 @@ final class TestUpdater implements TestUpdaterInterface
         $testResult
             ->setName($parser->getDisplayName() ?? $info->getName())
             ->setFullName($info->getFullName())
+            ->setTitlePath(...$info->getTitlePath())
             ->setDescriptionHtml($parser->getDescriptionHtml())
             ->setDescription($parser->getDescription())
             ->addLabels(

--- a/test/unit/Event/TestConsideredRiskySubscriberTest.php
+++ b/test/unit/Event/TestConsideredRiskySubscriberTest.php
@@ -34,16 +34,14 @@ final class TestConsideredRiskySubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestConsideredRiskySubscriber($testLifecycle);
-        $event = $this->createTestConsideredRiskyEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-            message: 'c',
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestConsideredRiskyEvent($test, 'c');
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Event/TestErroredSubscriberTest.php
+++ b/test/unit/Event/TestErroredSubscriberTest.php
@@ -34,16 +34,14 @@ final class TestErroredSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestErroredSubscriber($testLifecycle);
-        $event = $this->createTestErroredEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-            message: 'c',
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestErroredEvent($test, 'c');
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Event/TestFailedSubscriberTest.php
+++ b/test/unit/Event/TestFailedSubscriberTest.php
@@ -34,16 +34,14 @@ final class TestFailedSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestFailedSubscriber($testLifecycle);
-        $event = $this->createTestFailedEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-            message: 'c',
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestFailedEvent($test, 'c');
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Event/TestFinishedSubscriberTest.php
+++ b/test/unit/Event/TestFinishedSubscriberTest.php
@@ -33,15 +33,14 @@ final class TestFinishedSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestFinishedSubscriber($testLifecycle);
-        $event = $this->createTestFinishedEvent(
-            $this->createTestMethod(class: 'a', methodName: 'b'),
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestFinishedEvent($test);
 
         $lastMethod = null;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$lastMethod, $testLifecycle) {
                     $lastMethod = "switchTo";

--- a/test/unit/Event/TestMarkedIncompleteSubscriberTest.php
+++ b/test/unit/Event/TestMarkedIncompleteSubscriberTest.php
@@ -34,16 +34,14 @@ final class TestMarkedIncompleteSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestMarkedIncompleteSubscriber($testLifecycle);
-        $event = $this->createTestMarkedIncompleteEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-            message: 'c',
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestMarkedIncompleteEvent($test, 'c');
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Event/TestPassedSubscriberTest.php
+++ b/test/unit/Event/TestPassedSubscriberTest.php
@@ -34,15 +34,14 @@ final class TestPassedSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestPassedSubscriber($testLifecycle);
-        $event = $this->createTestPassesEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestPassesEvent($test);
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Event/TestPreparationStartedSubscriberTest.php
+++ b/test/unit/Event/TestPreparationStartedSubscriberTest.php
@@ -33,15 +33,14 @@ final class TestPreparationStartedSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestPreparationStartedSubscriber($testLifecycle);
-        $event = $this->createTestPreparationStartedEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestPreparationStartedEvent($test);
 
         $lastMethod = null;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$lastMethod, $testLifecycle) {
                     $lastMethod = "switchTo";

--- a/test/unit/Event/TestPreparedSubscriberTest.php
+++ b/test/unit/Event/TestPreparedSubscriberTest.php
@@ -33,15 +33,14 @@ final class TestPreparedSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestPreparedSubscriber($testLifecycle);
-        $event = $this->createTestPreparedEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestPreparedEvent($test);
 
         $lastMethod = null;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$lastMethod, $testLifecycle) {
                     $lastMethod = "switchTo";

--- a/test/unit/Event/TestSkippedSubscriberTest.php
+++ b/test/unit/Event/TestSkippedSubscriberTest.php
@@ -34,16 +34,14 @@ final class TestSkippedSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestSkippedSubscriber($testLifecycle);
-        $event = $this->createTestSkippedEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-            message: 'c',
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestSkippedEvent($test, 'c');
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Event/TestWarningTriggeredSubscriberTest.php
+++ b/test/unit/Event/TestWarningTriggeredSubscriberTest.php
@@ -34,16 +34,14 @@ final class TestWarningTriggeredSubscriberTest extends TestCase
     {
         $testLifecycle = $this->createMock(TestLifecycleInterface::class);
         $subscriber = new TestWarningTriggeredSubscriber($testLifecycle);
-        $event = $this->createTestWarningTriggeredEvent(
-            test: $this->createTestMethod(class: 'a', methodName: 'b'),
-            message: 'c',
-        );
+        $test = $this->createTestMethod(class: 'a', methodName: 'b');
+        $event = $this->createTestWarningTriggeredEvent($test, 'c');
 
         $switched = false;
         $testLifecycle
             ->expects(self::once())
             ->method('switchTo')
-            ->with(self::identicalTo('a::b'))
+            ->with(self::identicalTo($test))
             ->willReturnCallback(
                 function () use (&$switched, $testLifecycle) {
                     $switched = true;

--- a/test/unit/Internal/TestInfoTest.php
+++ b/test/unit/Internal/TestInfoTest.php
@@ -157,6 +157,43 @@ final class TestInfoTest extends TestCase
     }
 
     /**
+     * @param string|null $class
+     * @param list<string> $expectedTitlePath
+     * @psalm-suppress ArgumentTypeCoercion
+     */
+    #[DataProvider('providerGetTitlePath')]
+    public function testGetGetTitlePath_ConstructedWithGivenClass_ReturnsMatchingValue(
+        ?string $class,
+        array $expectedTitlePath,
+    ): void {
+        $info = new TestInfo(
+            test: 'a',
+            class: $class,
+            method: null,
+            dataLabel: null,
+            host: null,
+            thread: null,
+        );
+        self::assertEquals($expectedTitlePath, $info->getTitlePath());
+    }
+
+    /**
+     * @return iterable<string, array{string|null, list<string>}>
+     */
+    public static function providerGetTitlePath(): iterable
+    {
+        return [
+            "null class" => [null, []],
+            "empty class" => ["", []],
+            "no namespace" => ["Foo", ["Foo"]],
+            "one namespace" => ["Foo\\Bar", ["Foo", "Bar"]],
+            "nested namespaces" => ["Foo\\Bar\\Baz\\Qux", ["Foo", "Bar", "Baz", "Qux"]],
+            "absolute namespace path" => ["\\Foo\\Bar", ["Foo", "Bar"]],
+            "empty namespaces" => ["\\Foo\\\\Bar", ["Foo", "Bar"]],
+        ];
+    }
+
+    /**
      * @param string      $test
      * @param class-string|null $class
      * @param string|null $method

--- a/test/unit/TestTestLifecycle.php
+++ b/test/unit/TestTestLifecycle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\PHPUnit\Test\Unit;
 
+use PHPUnit\Event\Code\TestMethod;
 use Qameta\Allure\Model\Status;
 use Qameta\Allure\PHPUnit\Internal\TestLifecycleInterface;
 
@@ -34,7 +35,7 @@ final class TestTestLifecycle implements TestLifecycleInterface
     }
 
     #[\Override]
-    public function switchTo(string $test): TestLifecycleInterface
+    public function switchTo(TestMethod $test): TestLifecycleInterface
     {
         return $this;
     }


### PR DESCRIPTION
The PR uses the [new titlePath API]() to emit `titlePath` properties to test result files.

#### Extra changes

  - bump `allure-framework/allure-php-commons` to `^2.4` to get the titlePath API
  - refactor `TestInfo` factory method: instead of parsing `nameWithClass`, it now accesses the `TestMethod` instance, which gives ready-to-use values (the ones comprising `nameWithClass` to begin with).