### PR TITLE
Add explicit workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php-version }} PHPUnit ${{matrix.phpunit-version}} on ${{ matrix.os }}

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ labeled, unlabeled ]
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: zwaldowski/match-label-action@v6
         with:
-          allowed: 'type:bug,type:new feature,type:improvement,type:dependencies,type:internal,type:invalid'
+          allowed: 'type:bug,type:new feature,type:improvement,type:dependencies,type:internal,type:invalid,type:docs'

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -2,7 +2,7 @@ name: "Verify type labels"
 
 on:
   pull_request:
-    types: [ labeled, unlabeled ]
+    types: [opened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
The PR fixes `Workflow does not contain permissions` for `build.yml` and `labels-verify.yml`.

Additionally, the PR adds `opened` and `synchronize` types to the `pull_request` trigger of `labels-verify.yml` and adds the missing `type:docs` label.